### PR TITLE
Use Google fonts rather than downloading zip

### DIFF
--- a/app/css/ui_common.css
+++ b/app/css/ui_common.css
@@ -11,17 +11,17 @@
 
 @font-face {
     font-family: OpenSans-Italic;
-    src: url("../lib/open-sans/OpenSans-Italic.ttf");
+    src: url("../lib/open-sans-italic/index.woff");
 }
 
 @font-face {
     font-family: OpenSans-Regular;
-    src: url("../lib/open-sans/OpenSans-Regular.ttf");
+    src: url("../lib/open-sans/index.woff");
 }
 
 @font-face {
     font-family: OpenSans-SemiboldItalic;
-    src: url("../lib/open-sans/OpenSans-SemiboldItalic.ttf");
+    src: url("../lib/open-sans-semibold-italic/index.woff");
 }
 
 /* Color classes */

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "jquery": "~2.0.3",
     "iscroll": "4.2.5",
-    "open-sans": "http://www.fontsquirrel.com/fonts/download/open-sans"
+    "open-sans": "http://themes.googleusercontent.com/static/fonts/opensans/v6/cJZKeOuBrn4kERxqtaUH3T8E0i7KZn-EPnyo3HZu7kw.woff",
+    "open-sans-italic": "http://themes.googleusercontent.com/static/fonts/opensans/v6/xjAJXh38I15wypJXxuGMBobN6UDyHWBl620a-IRfuBk.woff",
+    "open-sans-semibold-italic": "http://themes.googleusercontent.com/static/fonts/opensans/v6/PRmiXeptR36kaC0GEAetxn5HxGBcBvicCpTp6spHfNo.woff"
   }
 }


### PR DESCRIPTION
As bower (at least v1.2.7) won't unzip a downloaded font package,
download the woff files individually from Google fonts instead.

Fixes #4
